### PR TITLE
Add overlay for real-time transcription

### DIFF
--- a/overlay.py
+++ b/overlay.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Simple overlay window displaying live transcriptions.
+
+Launches ``listener.py`` and shows the running transcript from
+``transcript.txt``. The window stays on top of other applications and can
+be resized normally.
+"""
+
+import sys
+import subprocess
+import pathlib
+from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
+from PySide6.QtCore import Qt, QTimer
+
+TRANSCRIPT_FILE = pathlib.Path("transcript.txt")
+
+
+def read_transcript() -> str:
+    if TRANSCRIPT_FILE.exists():
+        return TRANSCRIPT_FILE.read_text(encoding="utf-8")
+    return ""
+
+
+class Overlay(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Transcription Overlay")
+        self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
+
+        layout = QVBoxLayout(self)
+        self.label = QLabel()
+        self.label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.label.setWordWrap(True)
+        layout.addWidget(self.label)
+
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.update_text)
+        self.timer.start(500)
+        self.update_text()
+
+    def update_text(self) -> None:
+        self.label.setText(read_transcript())
+
+
+def main() -> None:
+    listener_proc = subprocess.Popen([sys.executable, "listener.py"])
+    app = QApplication(sys.argv)
+    window = Overlay()
+    window.resize(400, 200)
+    window.show()
+    ret = app.exec()
+    listener_proc.terminate()
+    listener_proc.wait()
+    sys.exit(ret)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- write transcribed segments to `transcript.txt` for display
- create PySide6 overlay window that stays above other apps and polls the transcript file

## Testing
- `python -m py_compile listener.py overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_68adc6c8964c83259069b04c50a1b38f