### PR TITLE
Add scrollable overlay and improve translation accuracy

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -11,7 +11,7 @@ from faster_whisper import WhisperModel
 from pykakasi import kakasi
 from jamdict import Jamdict
 from fugashi import Tagger
-from googletrans import Translator
+from deep_translator import GoogleTranslator
 
 # ================= Config (accuracy-first) =================
 TARGET_DEVICE_SUBSTR = "BlackHole"
@@ -36,7 +36,7 @@ def make_tagger():
     except Exception:
         return Tagger()  # fallback (likely unidic-lite)
 tagger = make_tagger()
-translator = Translator()
+translator = GoogleTranslator(source="ja", target="en")
 
 # ================= Device pick =================
 def pick_input(substr):
@@ -295,7 +295,7 @@ def append_transcript(text: str):
 def translate_text(text: str) -> str:
     """Translate Japanese text to English using Google Translate."""
     try:
-        return translator.translate(text, src="ja", dest="en").text
+        return translator.translate(text)
     except Exception:
         return ""
 

--- a/overlay.py
+++ b/overlay.py
@@ -9,7 +9,12 @@ be resized normally.
 import sys
 import subprocess
 import pathlib
-from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QApplication,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
 from PySide6.QtCore import Qt, QTimer
 
 TRANSCRIPT_FILE = pathlib.Path("transcript.txt")
@@ -28,11 +33,11 @@ class Overlay(QWidget):
         self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
 
         layout = QVBoxLayout(self)
-        self.label = QLabel()
-        self.label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.label.setTextFormat(Qt.RichText)
-        self.label.setWordWrap(True)
-        layout.addWidget(self.label)
+        self.text = QTextEdit()
+        self.text.setReadOnly(True)
+        self.text.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.text.setAcceptRichText(True)
+        layout.addWidget(self.text)
 
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.update_text)
@@ -51,7 +56,7 @@ class Overlay(QWidget):
                 chunks.append(f"{jp}<br><span style='color: gray'>{en}</span>")
             else:
                 chunks.append(jp)
-        self.label.setText("<br><br>".join(chunks))
+        self.text.setHtml("<br><br>".join(chunks))
 
 
 def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pykakasi
 jamdict
 jamdict-data
 PySide6
-googletrans==4.0.0rc1
+deep-translator


### PR DESCRIPTION
## Summary
- Replace Google Translate client with deep-translator for more reliable English output
- Display transcript in a read-only, scrollable text widget
- Update dependencies

## Testing
- `python -m py_compile overlay.py listener.py`
- `pip install deep-translator`


------
https://chatgpt.com/codex/tasks/task_e_68add317e9bc8325be660ca706a6c792